### PR TITLE
Improve performance for `MAX()` OR `COUNT()`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         dependencies:
           - "lowest"
           - "highest"
@@ -78,6 +80,8 @@ jobs:
       matrix:
         php-version:
           - "8.2"
+          - "8.3"
+          - "8.4"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,10 @@
     },
     "require": {
         "php": "^8.1",
-        "doctrine/orm": "^2.6"
+        "doctrine/orm": "^2.20 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^v3.16"
     }

--- a/src/ChunkGenerator.php
+++ b/src/ChunkGenerator.php
@@ -36,7 +36,7 @@ class ChunkGenerator implements Countable
         ?callable $onBeforeChunk = null,
         ?callable $onAfterChunk = null,
         ?callable $onBeforeDatum = null,
-        ?callable $onAfterDatum = null
+        ?callable $onAfterDatum = null,
     ) {
         $this->chunkSize = $chunkSize;
         $this->max = $max;

--- a/src/ChunkGeneratorBuilder.php
+++ b/src/ChunkGeneratorBuilder.php
@@ -157,16 +157,11 @@ class ChunkGeneratorBuilder
                     return $result;
                 }
 
-                return $query->iterate();
+                return $query->toIterable();
             })
-            /* @var array|object $datum */
-            ->onBeforeDatum(function ($datum) use ($fetchJoinCollection) {
-                if ($fetchJoinCollection) {
-                    return $datum;
-                }
-
-                /** @var array<mixed>|object $datum */
-                return current($datum);
+            /* @var object $datum */
+            ->onBeforeDatum(function ($datum) {
+                return $datum;
             })
             ->onAfterChunk(function (int $start, int $end, int $cnt, iterable $chunk) use ($manager) : void {
                 $manager->clear();

--- a/src/QueryOptimizer.php
+++ b/src/QueryOptimizer.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Kalibora\ChunkGenerator;
+
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use InvalidArgumentException;
+
+/**
+ * Optimize the query for performance
+ */
+final class QueryOptimizer
+{
+    /**
+     * Optimize the query for the maximum value (For MAX() or COUNT())
+     */
+    public function optimizeForMax(QueryBuilder $qb) : QueryBuilder
+    {
+        $qbForMax = clone $qb;
+
+        $rootAlias = $qb->getRootAliases()[0];
+
+        // Do not require ORDER BY
+        $qbForMax->resetDQLPart('orderBy');
+
+        // SELECT statements other than the main table are not necessary
+        $qbForMax->resetDQLPart('select')->addSelect($rootAlias);
+
+        // Narrow down to only JOIN the tables used in WHERE
+        return self::optimizeJoin($qbForMax);
+    }
+
+    /**
+     * Narrow down to only JOIN the tables used in WHERE
+     */
+    private static function optimizeJoin(QueryBuilder $qb) : QueryBuilder
+    {
+        // 1. Gather the aliases used in WHERE
+        $whereAliases = [];
+        self::gatherAlias($qb->getDQLPart('where'), $whereAliases);
+        $whereAliases = array_unique($whereAliases);
+
+        // 2. Checking JOIN dependencies
+        $joinParts = $qb->getDQLPart('join');
+        assert(is_array($joinParts));
+        $joinDependencyMap = self::createJoinDependencyMap($joinParts);
+
+        // 3. Gather the aliases used in WHERE or its dependencies
+        $rootAlias = $qb->getRootAliases()[0];
+        $requiredAliases = [];
+        foreach ($whereAliases as $whereAlias) {
+            $requiredAliases[] = $whereAlias;
+
+            self::gatherJoinDependency($rootAlias, $whereAlias, $joinDependencyMap, $requiredAliases);
+        }
+
+        $requiredAliases = array_unique($requiredAliases);
+
+        // 4. Narrow down to just the required aliases
+        $requiredJoins = [];
+        foreach ($joinParts as $rootAlias => $joins) {
+            foreach ($joins as $join) {
+                if (in_array($join->getAlias(), $requiredAliases, true)) {
+                    $requiredJoins[$rootAlias][] = $join;
+                }
+            }
+        }
+        $qb->resetDQLPart('join');
+        foreach ($requiredJoins as $rootAlias => $joins) {
+            foreach ($joins as $join) {
+                $qb->add('join', [$rootAlias => $join], true);
+            }
+        }
+
+        return $qb;
+    }
+
+    /**
+     * Gather the aliases used from the Expr of DQL
+     *
+     * @param list<string> &$aliases
+     */
+    private static function gatherAlias(mixed $expr, array &$aliases) : void
+    {
+        $expr_list = null;
+
+        if (is_array($expr)) {
+            $expr_list = $expr;
+        } elseif ($expr instanceof Expr\Andx
+            || $expr instanceof Expr\Orx
+            || $expr instanceof Expr\GroupBy
+            || $expr instanceof Expr\Literal
+            || $expr instanceof Expr\OrderBy
+        ) {
+            $expr_list = $expr->getParts();
+        }
+
+        if ($expr_list !== null) {
+            foreach ($expr_list as $ex) {
+                self::gatherAlias($ex, $aliases);
+            }
+
+            return;
+        }
+
+        if ($expr !== null) {
+            $aliases[] = self::extractAliasFromExpr($expr);
+        }
+    }
+
+    private static function extractAliasFromExpr(mixed $expr) : string
+    {
+        if ($expr instanceof Expr\Select) {
+            foreach ($expr->getParts() as $part) {
+                if ($part instanceof Expr\Func) {
+                    throw new InvalidArgumentException('Not supported yet for alias in Expr\Func');
+                }
+
+                return $part;
+            }
+        }
+
+        if ($expr instanceof Expr\Comparison) {
+            $leftExpr = $expr->getLeftExpr();
+            if (! is_string($leftExpr)) {
+                throw new InvalidArgumentException('Not supported yet for alias in ' . get_debug_type($leftExpr));
+            }
+            list($alias) = explode('.', $leftExpr);
+
+            return $alias;
+        }
+
+        if ($expr instanceof Expr\Func) {
+            list($alias) = explode('.', $expr->getName());
+
+            return $alias;
+        }
+
+        if (is_string($expr)) {
+            // LIKE 'a.status = :status'
+            // LIKE 'a.status IS NULL'
+            // LIKE 'a.status IS NOT NULL'
+            // The above and other constructions such as IN clauses are also allowed, so the decision is made based on 'count($splited) >= 3'.
+            $splited = preg_split('/\s+/', $expr);
+
+            if (is_array($splited) && count($splited) >= 3) {
+                // LIKE a.status
+                $leftExpr = $splited[0];
+                list($alias) = explode('.', $leftExpr);
+
+                return $alias;
+            }
+        }
+
+        throw new InvalidArgumentException('Not supported yet for alias in ' . get_debug_type($expr));
+    }
+
+    /**
+     * Checking JOIN dependencies
+     *
+     * @param array<string, array<Expr\Join>> $joinParts
+     *
+     * @return array<string|null, string>
+     */
+    private static function createJoinDependencyMap(array $joinParts) : array
+    {
+        $dependencyMap = [];
+
+        foreach ($joinParts as $rootAlias => $joins) {
+            foreach ($joins as $join) {
+                list($parentAlias) = explode('.', $join->getJoin());
+
+                $dependencyMap[$join->getAlias()] = $parentAlias;
+            }
+        }
+
+        return $dependencyMap;
+    }
+
+    /**
+     * Gather all the aliases that require JOIN between the specified alias and the root alias.
+     *
+     * @param array<string|null, string> $joinDependencyMap
+     * @param list<mixed>                &$dependencyAliases
+     */
+    private static function gatherJoinDependency(string $rootAlias, mixed $alias, array $joinDependencyMap, array &$dependencyAliases) : void
+    {
+        if (! isset($joinDependencyMap[$alias])) {
+            return;
+        }
+
+        $dependencyAlias = $joinDependencyMap[$alias];
+
+        if ($dependencyAlias === $rootAlias) {
+            return;
+        }
+
+        $dependencyAliases[] = $dependencyAlias;
+
+        self::gatherJoinDependency($rootAlias, $dependencyAlias, $joinDependencyMap, $dependencyAliases);
+    }
+}

--- a/tests/QueryOptimizerTest.php
+++ b/tests/QueryOptimizerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Kalibora\ChunkGenerator;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+class QueryOptimizerTest extends TestCase
+{
+    /**
+     * @dataProvider provideOptimizeForMax
+     */
+    public function testOptimizeForMax(callable $qbModifier, string $expectedDql)
+    {
+        $em = self::getMockBuilder(EntityManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $qb = new QueryBuilder($em);
+        $qbModifier($qb);
+
+        $optimizer = new QueryOptimizer();
+        $qbForMax = $optimizer->optimizeForMax($qb);
+
+        $this->assertSame($expectedDql, $qbForMax->getDQL());
+    }
+
+    public static function provideOptimizeForMax() : iterable
+    {
+        yield 'No JOIN, No WHERE' => [
+            function (QueryBuilder $qb) {
+                $qb->select('u')->from('User', 'u');
+            },
+            'SELECT u FROM User u',
+        ];
+
+        yield 'No JOIN, WHERE is only the main table' => [
+            function (QueryBuilder $qb) {
+                $qb->select('u')->from('User', 'u')->where('u.name LIKE :username');
+            },
+            'SELECT u FROM User u WHERE u.name LIKE :username',
+        ];
+
+        yield 'JOIN, No WHERE' => [
+            function (QueryBuilder $qb) {
+                $qb
+                    ->select('u, e')
+                    ->from('User', 'u')
+                    ->join('u.address', 'a')
+                    ->join('u.email', 'e', Expr\Join::WITH, 'e.userId = u.id')
+                    ->orderBy('u.name')
+                ;
+            },
+            'SELECT u FROM User u',
+        ];
+
+        yield 'JOIN, WHERE is only the main table' => [
+            function (QueryBuilder $qb) {
+                $qb
+                    ->select('u, e')
+                    ->from('User', 'u')
+                    ->join('u.address', 'a')
+                    ->join('u.email', 'e', Expr\Join::WITH, 'e.userId = u.id')
+                    ->where('u.name LIKE :username')
+                    ->orderBy('u.name')
+                ;
+            },
+            'SELECT u FROM User u WHERE u.name LIKE :username',
+        ];
+
+        yield 'JOIN, WHERE has conditions for related tables' => [
+            function (QueryBuilder $qb) {
+                $qb
+                    ->select('u, e')
+                    ->from('User', 'u')
+                    ->join('u.address', 'a')
+                    ->join('u.email', 'e', Expr\Join::WITH, 'e.userId = u.id')
+                    ->where('u.name LIKE :username')
+                    ->andWhere('e.email LIKE :email')
+                    ->orderBy('u.name')
+                ;
+            },
+            'SELECT u FROM User u INNER JOIN u.email e WITH e.userId = u.id WHERE u.name LIKE :username AND e.email LIKE :email',
+        ];
+    }
+}


### PR DESCRIPTION
The query used to obtain the maximum value used internally in `ChunkGeneratorBuilder::setDoctrineQueryBuilder()` has been optimized to improve performance.
